### PR TITLE
DEVOPS-3763: adjusting archive to use full version

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,7 +44,7 @@ class nexus::package (
 
   $full_version = "${version}-${revision}"
 
-  $nexus_archive   = "nexus-${version}-bundle.tar.gz"
+  $nexus_archive   = "nexus-${full_version}-bundle.tar.gz"
   $download_url    = "${download_site}/${nexus_archive}"
   $dl_file         = "${nexus_root}/${nexus_archive}"
   $nexus_home_real = "${nexus_root}/nexus-${full_version}"


### PR DESCRIPTION
This change will ensure that the download of the Nexus tarball uses the full version, which includes both the version and the revision.